### PR TITLE
Zero Flags implementation

### DIFF
--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -241,6 +241,7 @@ class PIC16F628A:
 
     def clrw(self):
         self.Accumulator.bits = 0
+        self.__status_zero_flag(self.Accumulator.bits)
         self.__increase_KCS()
 
     def bcf(self,f,b):

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -179,6 +179,7 @@ class PIC16F628A:
 
     def andlw(self,k):
         self.Accumulator.assign_bits(k & self.Accumulator.bits)
+        self.__status_zero_flag(self.Accumulator.bits)
         self.__increase_KCS()
 
     def andwf(self,f,d):

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -203,6 +203,7 @@ class PIC16F628A:
 
     def xorlw(self,k):
         self.Accumulator.assign_bits(k ^ self.Accumulator.bits)
+        self.__status_zero_flag(self.Accumulator.bits)
         self.__increase_KCS()
 
     def xorwf(self,f,d):

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -236,6 +236,7 @@ class PIC16F628A:
 
     def clrf(self,f):
         self.RAM[f].bits = 0
+        self.__status_zero_flag(self.RAM[f].bits)
         self.__increase_KCS()
 
     def clrw(self):

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -164,8 +164,10 @@ class PIC16F628A:
     def incf(self,f,d):
         if d == 1:
             self.RAM[f].assign_bits(self.RAM[f].bits + 1)
+            self.__status_zero_flag(self.RAM[f].bits)
         elif d == 0:
             self.Accumulator.assign_bits(self.RAM[f].bits + 1)
+            self.__status_zero_flag(self.Accumulator.bits)
         self.__increase_KCS()
 
     def decf(self,f,d):

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -228,9 +228,11 @@ class PIC16F628A:
     def comf(self,f,d):
         if d == 1:
             self.RAM[f].assign_bits(self.RAM[f].ones_complement())
+            self.__status_zero_flag(self.RAM[f].bits)
         elif d == 0:
             temp=self.RAM[f].bits
             self.Accumulator.assign_bits(self.RAM[f].ones_complement())
+            self.__status_zero_flag(self.Accumulator.bits)
             self.RAM[f].bits=temp
         self.__increase_KCS()
 

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -189,8 +189,10 @@ class PIC16F628A:
     def andwf(self,f,d):
         if d == 1:
             self.RAM[f].assign_bits(self.RAM[f].bits & self.Accumulator.bits)
+            self.__status_zero_flag(self.RAM[f].bits)
         elif d == 0:
             self.Accumulator.assign_bits(self.RAM[f].bits & self.Accumulator.bits)
+            self.__status_zero_flag(self.Accumulator.bits)
         self.__increase_KCS()
 
     def iorlw(self,k):

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -92,9 +92,9 @@ class PIC16F628A:
         d: int
         """
         if d == 1:
-            self.RAM[f].bits = self.RAM[f].bits
+            self.RAM[f].assign_bits(self.RAM[f].bits)
         elif d == 0:
-            self.Accumulator.bits = self.RAM[f].bits
+            self.Accumulator.assign_bits(self.RAM[f].bits)
         self.__increase_KCS()
         return self.RAM[f].bits
 

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -93,8 +93,10 @@ class PIC16F628A:
         """
         if d == 1:
             self.RAM[f].assign_bits(self.RAM[f].bits)
+            self.__status_zero_flag(self.RAM[f].bits)
         elif d == 0:
             self.Accumulator.assign_bits(self.RAM[f].bits)
+            self.__status_zero_flag(self.Accumulator.bits)
         self.__increase_KCS()
         return self.RAM[f].bits
 

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -142,6 +142,7 @@ class PIC16F628A:
 
     def addlw(self,k):
         self.Accumulator.assign_bits(k + self.Accumulator.bits)
+        self.__status_zero_flag(self.Accumulator.bits)
         self.__increase_KCS()
 
     def subwf(self,f,d):

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -217,8 +217,10 @@ class PIC16F628A:
     def xorwf(self,f,d):
         if d == 1:
             self.RAM[f].assign_bits(self.RAM[f].bits ^ self.Accumulator.bits)
+            self.__status_zero_flag(self.RAM[f].bits)
         elif d == 0:
             self.Accumulator.assign_bits(self.RAM[f].bits ^ self.Accumulator.bits)
+            self.__status_zero_flag(self.Accumulator.bits)
         self.__increase_KCS()
 
     def comf(self,f,d):

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -191,6 +191,7 @@ class PIC16F628A:
 
     def iorlw(self,k):
         self.Accumulator.assign_bits(k | self.Accumulator.bits)
+        self.__status_zero_flag(self.Accumulator.bits)
         self.__increase_KCS()
 
     def iorwf(self,f,d):

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -203,8 +203,10 @@ class PIC16F628A:
     def iorwf(self,f,d):
         if d == 1:
             self.RAM[f].assign_bits(self.RAM[f].bits | self.Accumulator.bits)
+            self.__status_zero_flag(self.RAM[f].bits)
         elif d == 0:
             self.Accumulator.assign_bits(self.RAM[f].bits | self.Accumulator.bits)
+            self.__status_zero_flag(self.Accumulator.bits)
         self.__increase_KCS()
 
     def xorlw(self,k):

--- a/pic16f628a.py
+++ b/pic16f628a.py
@@ -173,8 +173,10 @@ class PIC16F628A:
     def decf(self,f,d):
         if d == 1:
             self.RAM[f].assign_bits(self.RAM[f].bits-1)
+            self.__status_zero_flag(self.RAM[f].bits)
         elif d == 0:
             self.Accumulator.assign_bits(self.RAM[f].bits-1)
+            self.__status_zero_flag(self.Accumulator.bits)
         self.__increase_KCS()
     
     # Boolean...


### PR DESCRIPTION
Zero Flags implemented for these:

- [x] addlw
- [x] addwf
- [x] andlw
- [x] andwf
- [x] clrf
- [x] clrw
- [x] comf
- [x] decf
- [x] incf
- [x] iorlw
- [x] iorwf
- [x] movf
- [x] sublw
- [x] subwf
- [x] xorlw
- [x] xorwf

I couldn't understand why or how some of those affect Zero Flag. Good luck!..